### PR TITLE
Add ThemeProvider and Update App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Container, Link, Box, Text, Flex, Button } from '@radix-ui/themes';
 import { Routes, Route, Outlet, Link as RouterLink } from 'react-router-dom';
 import tj from './assets/tj-avatar.png';
-import { useState } from 'react';
+import { useTheme } from './components/theme-provider';
 
 export default function App() {
   return (
@@ -16,7 +16,7 @@ export default function App() {
 }
 
 function Page() {
-  const [time, setTime] = useState('light');
+  const { setTheme } = useTheme();
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-between p-16">
@@ -42,10 +42,10 @@ function Page() {
           </Box>
           <Box width="400px">
             <Flex gap="6" direction="row" justify="center">
-              <Button size="4" onClick={() => setTime('light')}>
+              <Button size="4" onClick={() => setTheme('light')}>
                 Morning
               </Button>
-              <Button size="4" onClick={() => setTime('dark')}>
+              <Button size="4" onClick={() => setTheme('dark')}>
                 Evening
               </Button>
             </Flex>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'dark' | 'light';
+
+type ThemeProviderProps = {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+};
+
+type ThemeProviderState = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
+
+const initialState: ThemeProviderState = {
+  theme: 'light',
+  setTheme: () => null,
+};
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
+
+export function ThemeProvider({
+  children,
+  defaultTheme = 'light',
+  ...props
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(() => defaultTheme);
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+
+    root.classList.remove('light', 'dark');
+
+    root.classList.add(theme);
+  }, [theme]);
+
+  const value = {
+    theme,
+    setTheme: (theme: Theme) => {
+      setTheme(theme);
+    },
+  };
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  );
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext);
+
+  if (context === undefined)
+    throw new Error('useTheme must be used within a ThemeProvider');
+
+  return context;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,13 +5,16 @@ import App from './App.tsx';
 import './index.css';
 import '@radix-ui/themes/styles.css';
 import { Theme } from '@radix-ui/themes';
+import { ThemeProvider } from './components/theme-provider.tsx';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <Theme>
-        <App />
-      </Theme>
+      <ThemeProvider defaultTheme="light">
+        <Theme>
+          <App />
+        </Theme>
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Changes:

- Added `theme-provider` Component
- Wrapped `Theme` and `App` with new `ThemeProvider`
- Updated App to use `useTheme`.

## Considerations:
Looking into allowing a user to change the theme, [Radixui recommended](https://www.radix-ui.com/themes/docs/theme/dark-mode#inheriting-system-appearance) use of a ThemeProvider. I was able to locate a provider for use and modified the code to fit the use case.
**Source for ThemeProvider** - https://ui.shadcn.com/docs/dark-mode/vite
- Modifications - Set default theme to light mode. Removed checking for system preferences to maintain story experience. Removed setting theme preference in localstorage to prevent flash when setting dark mode and refreshing the page. This also maintains the story experience.